### PR TITLE
T-SUPA-05: Env keys setup (.env.example)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Example environment variables for AgentFlow
+# Copy this file to `.env` and fill in values.
+
+# Supabase project settings
+# Find these in Supabase Dashboard: Project Settings → API
+SUPABASE_URL=
+SUPABASE_ANON_KEY=
+# Service role key is sensitive. Do not expose to client/browser.
+SUPABASE_SERVICE_ROLE_KEY=
+
+# Optional: OpenAI key for local tools or Studio AI
+# OPENAI_API_KEY=
+

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -9,6 +9,13 @@ Prerequisites
 - Supabase CLI installed: https://supabase.com/docs/guides/cli
 - Docker running (for local dev via `supabase start`).
 
+Environment keys (.env)
+- Copy `.env.example` to `.env` at repo root.
+- Fill the following from Supabase Dashboard → Project Settings → API:
+  - `SUPABASE_URL`
+  - `SUPABASE_ANON_KEY`
+  - `SUPABASE_SERVICE_ROLE_KEY` (server-only; never expose to browser)
+
 Local development (Docker)
 1) Start stack
    - `supabase start`
@@ -24,4 +31,3 @@ Hosted project (apply migrations)
 Notes
 - The migration is idempotent (`create extension if not exists vector;`).
 - Keep future schema changes as new numbered files under `supabase/migrations/`.
-

--- a/tasks.md
+++ b/tasks.md
@@ -35,7 +35,7 @@
  - [x] **T-SUPA-02** สร้างตารางและดัชนีหลัก `projects`, `requirements`, `artifacts`, `tasks`, `task_dependencies`, `agent_runs`, `messages`, `memories`, `project_members`
  - [x] **T-SUPA-03** เขียน RLS policies สำหรับ projects และ tasks รวมถึงตารางที่เกี่ยวข้อง
 - [x] **T-SUPA-04** ตั้ง Storage bucket ชื่อ `artifacts` และโครงพาธ `artifacts/<projectId>/...`
-- [ ] **T-SUPA-05** ตั้งค่า `.env` ใส่ `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`
+ - [x] **T-SUPA-05** ตั้งค่า `.env` ใส่ `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`
 
 ### C. Next.js Web UI และ Orchestrator TS
 - [ ] **T-WEB-01** สร้าง Next.js TypeScript พร้อม Tailwind, shadcn ui, Zustand


### PR DESCRIPTION
Implements T-SUPA-05:\n- Add root .env.example with SUPABASE_URL, SUPABASE_ANON_KEY, SUPABASE_SERVICE_ROLE_KEY\n- Update supabase/README.md with env setup notes\n- Mark T-SUPA-05 as done in tasks.md\n\nNotes:\n- .gitignore already excludes .env; .env.example is committed\n- SERVICE_ROLE_KEY is server-only; never expose to client